### PR TITLE
2023/24 update including splitting by diabetes type (1 and 2)

### DIFF
--- a/Diabetes update.R
+++ b/Diabetes update.R
@@ -342,8 +342,14 @@ deaths_diab <- tibble::as_tibble(
                      TRUE ~ NA))
    
   #Join all-sex data back on
-  deaths_diab_cleaned <- rbind(deaths_diab_sex, deaths_totals)
+  deaths_diab_cleaned <- rbind(deaths_diab_sex, deaths_totals) |> 
+    rename(Numerator = numerator, 
+           Rate = rate) |> 
+    #Finally pivoting longer so that rates and numerators become one col called measure
+    pivot_longer(cols = c("Numerator", "Rate"), names_to = "measure", values_to = "value") |> 
+    mutate(value =round(value, digits = 1))
+    
   
-  
+  saveRDS(deaths_diab_cleaned, paste0(output, "/deaths_data_shiny_test.rds"))
 
 ##END

--- a/Diabetes update.R
+++ b/Diabetes update.R
@@ -15,14 +15,14 @@ library(stringr)
 
 # set files paths. folder will have to be created for newest year's data
 
-  output <- "/PHI_conf/ScotPHO/Website/Topics/Diabetes/Data/Mar25"
+  output <- "/PHI_conf/ScotPHO/Website/Topics/Diabetes/Data/Jun25"
   lookups <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Population/"
 
 ###############################################.
 ## Part 1 - Population files ----
 ###############################################.
 population <- readRDS(paste0(lookups, "CA_pop_allages_SR.rds")) |> 
-  filter(code == 'S00000001') %>%  # Selecting only Scotland level
+  filter(code == 'S00000001') |>   # Selecting only Scotland level
   add_epop() |>  # Add European Standard Populations for each age group
   # Create required age groups  (<25, 25-44, 45-64, 65+)
   mutate(age_grp2 = case_when(between(age_grp, 1, 5) ~ "<25",
@@ -41,217 +41,225 @@ channel <- suppressWarnings(dbConnect(odbc(),  dsn="SMRA",
                                       uid=.rs.askForPassword("SMRA Username:"), 
                                       pwd=.rs.askForPassword("SMRA Password:")))
 
-# This query extracts data for all episodes of patients for which in any ocassion there was a diagnosis of diabetes.
-# It exclude patients with no sex recorded (8 cases) and non-scottish patients.
-# It does creates variables to see if diabetes is in the diagnosis of the episode, if it is the main cause 
-# and if there is a diagnosis of ketoacidosis. It should take ~ 5 mins to run.
-# Create one record per CIS selecting the admission date and personal/geographical details from 
-# the first episode of the CIS, the latest discharge date of the CIS, ensuring all required diagnoses are captured.
-admissions_diab <- tibble::as_tibble(dbGetQuery(channel, statement=
-"SELECT sum(z.E10_main) E10_main, sum(z.E11_main) E11_main, sum(z.other_main) other_main, sum(z.E10_any) E10_any,
- sum(z.E11_any) E11_any, sum(z.other_any) other_any, sum(z.E10_keto) E10_keto, sum(z.E11_keto) E11_keto,
-    z.year, z.age, z.sex
-  FROM (SELECT distinct link_no | | cis_marker CIS, max(age_in_years) age, max(sex) sex, 
-      max(CASE WHEN extract(month from discharge_date) > 3 THEN extract(year from discharge_date) 
-            ELSE extract(year from discharge_date) -1 END) as year, 
-      max(CASE WHEN regexp_like(main_condition, 'E10') then 1 else 0 end) E10_main,
-      max(CASE WHEN regexp_like(main_condition, 'E11') then 1 else 0 end) E11_main,
-      max(CASE WHEN regexp_like(main_condition, 'E1[234]') then 1 else 0 end) other_main,
-      max(CASE WHEN regexp_like(main_condition, 'E10') then 1 else 0 end) E10_keto,
-      max(CASE WHEN regexp_like(main_condition, 'E11') then 1 else 0 end) E11_keto,
-      max(CASE WHEN regexp_like(main_condition || other_condition_1 || other_condition_2
-            || other_condition_3 || other_condition_4 || other_condition_5, 'E10')
-            THEN 1 ELSE 0 END) E10_any, 
-      max(CASE WHEN regexp_like(main_condition || other_condition_1 || other_condition_2
-            || other_condition_3 || other_condition_4 || other_condition_5, 'E11')
-            THEN 1 ELSE 0 END) E11_any,
-      max(CASE WHEN regexp_like(main_condition || other_condition_1 || other_condition_2
-            || other_condition_3 || other_condition_4 || other_condition_5, 'E1[234]')
-            THEN 1 ELSE 0 END) other_any 
-    FROM ANALYSIS.SMR01_PI 
-    WHERE discharge_date between '1 April 2011' and '31 March 2024'
-      and hbtreat_currentdate is not null 
-      and sex in ('1','2') 
-      and regexp_like(main_condition || other_condition_1 || other_condition_2
-            || other_condition_3 || other_condition_4 || other_condition_5, 'E1[01234]') 
-    GROUP BY link_no | | cis_marker) z  
- GROUP BY z.year, z.age, z.sex")) |> 
-  janitor::clean_names()  #variables to lower case
+# This query extracts data for all episodes of patients for which in any occasion there was a diagnosis of diabetes.
+# It excludes patients with no sex recorded and patients who were not Scottish residents
 
+admissions_diab_test <- tibble::as_tibble(dbGetQuery(channel, statement = 
+"Select age_in_years, sex, main_condition, other_condition_1, other_condition_2, 
+other_condition_3, other_condition_4, other_condition_5, discharge_date, uri, cis_marker, link_no
+FROM ANALYSIS.SMR01_PI
+WHERE(
+discharge_date between '1 January 2024' and '31 March 2024'
+and hbtreat_currentdate is not null
+and sex in ('1', '2')
+and regexp_like(main_condition || other_condition_1 || other_condition_2
+            || other_condition_3 || other_condition_4 || other_condition_5, 'E1[01234]'))
+ORDER BY link_no, cis_marker, discharge_date, uri"))
 
-#Age groups and aggregating by sex, year and age group
-admissions_diab <- admissions_diab |> create_agegroups() |>  
+#Tweak columns for easier interpretation e.g. change sex from numeric to character, 
+#Generate new columns identifying diabetes type, presence of ketoacidosis in admission, and whether the admission
+#was primarily due to diabetes or not
+
+admissions_diab <- admissions_diab_test |> 
+  janitor::clean_names() |> #convert variable names to lower case
+  mutate(fin_year = phsmethods::extract_fin_year(discharge_date)) |>    #convert the date of discharge into a financial year
+  rowwise() |> #needed for mutating multiple cols at once
+  mutate(year = as.numeric(substr(fin_year, 1, 4)),
+         age = age_in_years, #rename to match analysis function
+         # sex = case_when(sex == 1 ~ "Male", #converts sex from numeric to string
+         #                 sex == 2 ~ "Female"),
+         diab_keto = if_else(any(stringr::str_detect(c_across(3:8), 'E101|E111|E121|E131|E141'), na.rm = TRUE), 1, 0), #searches all condition spaces for diabetic ketoacidosis and flags if found
+         diab_type = case_when(
+           any(str_detect(c_across(3:8), '^E10'), na.rm = TRUE) ~ "Type 1", #populates diab_type column with the diabetes type based on all diagnosis columns
+           any(str_detect(c_across(3:8), '^E11'), na.rm = TRUE) ~ "Type 2",
+           TRUE ~ "Other Diabetes"),
+         diab_main_flag = case_when(str_detect(main_condition, "E1[01234]") ~ "Main Position", TRUE ~ "Any Position")) |>  #identifies whether diabetes was the primary cause of admission
+  ungroup()
+
+#Calculate age groups and aggregate data
+admissions_diab_2 <- admissions_diab |> create_agegroups() |>  
   mutate(age_grp2 = case_when(between(age_grp, 1, 5) ~ "<25",
                               between(age_grp, 6, 9) ~ "25-44",
                               between(age_grp, 10, 13) ~ "45-64",
                               between(age_grp, 14, 19) ~ "65+")) |> 
-  group_by(year, sex, age_grp, age_grp2) |> 
-  summarize_at(c("e10_main", "e11_main", "other_main", "e10_keto", "e11_keto", "e10_any", "e11_any", "other_any"), sum, na.rm = T) |>  
-  #From wide to long format
-  gather(type, numerator, -c(year, sex, age_grp, age_grp2)) |>  ungroup()
+  group_by(sex, year, diab_keto, diab_type, diab_main_flag, age_grp, age_grp2) |> #counting number of admissions for each category
+  summarise(numerator = n(), .groups = "drop") |> 
+  complete(sex, year, diab_keto, diab_type, diab_main_flag, age_grp2, fill = list(numerator = 0)) #filling in blank categories with 0 admissions
+
+  
+  all_sexes <- admissions_diab_2 |> #combining the data for males and females to get a count for both sexes combined
+    group_by(year, diab_keto, diab_type, diab_main_flag, age_grp, age_grp2) |> 
+    summarise(numerator = sum(numerator), .groups = "drop") |> 
+    mutate(sex = "All")
+  
+  admissions_diab_2 <- rbind(admissions_diab_2, all_sexes) #appending data for both sexes onto sex-split data
 
 #Bringing population information to calculate rates.
-admissions_diab <- left_join(admissions_diab, population, 
+admissions_diab_3 <- left_join(admissions_diab_2, population, 
                              by = c("year", "sex", "age_grp", "age_grp2")) |>  
-  add_epop() #adding European population for rate calculation
+  add_epop() |> #adding European population for rate calculation 
+  group_by(sex, year, diab_keto, diab_type, diab_main_flag, age_grp2) |> 
+    summarise(across(c(numerator, denominator, epop), sum), .groups = "drop") 
 
-saveRDS(admissions_diab, file = paste0(output, "/diabetes_admissions_basefile.rds"))
+
+
+saveRDS(admissions_diav, file = paste0(output, "/diabetes_admissions_basefile.rds"))
 admissions_diab <- readRDS(paste0(output, "/diabetes_admissions_basefile.rds")) 
-
-###############################################.
-# Creating file for Secondary care section chart 1.
-# Chart 1 - admissions for type one diabetes in main or any position split by sex
-seccare_c1 <- admissions_diab |> 
-  filter(type == "e10_main" | type == "e10_any") 
-
-#Create totals for both sexes
-seccare_c1_total <- seccare_c1 |> 
-  group_by(year, age_grp, age_grp2, type) |>
-  summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup() |>
-  mutate(sex = "All")
-
-# # Calculating rates for all and for each sex
-seccare_c1_total <- seccare_c1_total |>  create_rates(cats = "type", epop_total = 200000, sex = T)
-seccare_c1_sex <- seccare_c1 |>  create_rates(cats = "type", epop_total = 100000, sex = T)
-
-# # Preparing file for chart
-seccare_c1 <- rbind(seccare_c1_total, seccare_c1_sex) |>
-  #Creating labels for chart
-  mutate(class1 = case_when(type == "e10_main" & sex == "All" ~ "All - main diagnosis",
-                            type == "e10_any" & sex == "All" ~ "All - any diagnosis",
-                            type == "e10_main" & sex == "1" ~ "Male - main diagnosis",
-                            type == "e10_main" & sex == "2" ~ "Female - main diagnosis",
-                            type == "e10_any" & sex == "1" ~ "Male - any diagnosis",
-                            type == "e10_any" & sex == "2" ~ "Female - any diagnosis")) |> 
-  make_year_labels(year_type = "financial") |> #Relabeling years
-  rename(class2 = year) |>  select(class2, class1, numerator, rate)
-  
-write_csv(seccare_c1, paste0(output, "/diabetes_secondarycare_chart1.csv"))
-
-###############################################.
-# Creating file for Secondary care section chart 2.
-#Chart 2 - admissions for type 2 diabetes in main or any position split by sex
-seccare_c2 <- admissions_diab |> 
-  filter(type == "e11_main" | type == "e11_any") 
-
-#Create totals for both sexes
-seccare_c2_total <- seccare_c2 |> 
-  group_by(year, age_grp, age_grp2, type) |>
-  summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup() |>
-  mutate(sex = "All")
-
-# # Calculating rates for all and for each sex
-seccare_c2_total <- seccare_c2_total |>  create_rates(cats = "type", epop_total = 200000, sex = T)
-seccare_c2_sex <- seccare_c2 |>  create_rates(cats = "type", epop_total = 100000, sex = T)
-
-# # Preparing file for chart
-seccare_c2 <- rbind(seccare_c2_total, seccare_c2_sex) |>
-  #Creating labels for chart
-  mutate(class1 = case_when(type == "e11_main" & sex == "All" ~ "All - main diagnosis",
-                            type == "e11_any" & sex == "All" ~ "All - any diagnosis",
-                            type == "e11_main" & sex == "1" ~ "Male - main diagnosis",
-                            type == "e11_main" & sex == "2" ~ "Female - main diagnosis",
-                            type == "e11_any" & sex == "1" ~ "Male - any diagnosis",
-                            type == "e11_any" & sex == "2" ~ "Female - any diagnosis")) |> 
-  make_year_labels(year_type = "financial") |> #Relabeling years
-  rename(class2 = year) |>  select(class2, class1, numerator, rate)
-
-write_csv(seccare_c2, paste0(output, "/diabetes_secondarycare_chart2.csv"))
-
-###############################################.
-# Creating file for Secondary care section chart 3.
-# ketoacidosis - splitting by type 1 and 2
-seccare_c3_filtered <- admissions_diab |> 
-  filter(type == "e10_keto") 
-
-seccare_c3_total<- seccare_c3_filtered|> 
-  group_by(sex, year, age_grp, age_grp2, type) |>
-  summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup()
-
-
-seccare_c3_e10 <- rbind( #calculating rates for each age group
-  # For under 25 group group
-  admissions_diab |>  filter(age_grp2 == "<25" & type == "e10_keto") |>  
-    create_rates(cats = "age_grp2", epop_total = 27500, sex = T),
-  # For 25 to 44 group
-  admissions_diab |>  filter(age_grp2 == "25-44" & type == "e10_keto") |>  
-    create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
-  # For 45 to 64 group
-  admissions_diab |>  filter(age_grp2 == "45-64" & type == "e10_keto") |> 
-    create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
-  # For over 65 group
-  admissions_diab |> filter(age_grp2 == "65+" & type == "e10_keto") |>  
-    create_rates(cats = "age_grp2", epop_total = 19500, sex = T),
-  # all ages by sex 
-  seccare_c3 |>  create_rates(cats = "type", epop_total = 100000, sex = T) |> 
-    select(-type) |>  
-    mutate(age_grp2 =  "All")) |> 
-  mutate(type = "e10_keto")
-
-seccare_c3_filtered <- admissions_diab |> 
-  filter(type == "e11_keto") 
-
-seccare_c3_total<- seccare_c3_filtered |> 
-  group_by(sex, year, age_grp, age_grp2, type) |>
-  summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup()
-
-
-seccare_c3_e11 <- rbind( #calculating rates for each age group
-  # For under 25 group group
-  admissions_diab |>  filter(age_grp2 == "<25" & type == "e11_keto") |>  
-    create_rates(cats = "age_grp2", epop_total = 27500, sex = T),
-  # For 25 to 44 group
-  admissions_diab |>  filter(age_grp2 == "25-44" & type == "e11_keto") |>  
-    create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
-  # For 45 to 64 group
-  admissions_diab |>  filter(age_grp2 == "45-64" & type == "e11_keto") |> 
-    create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
-  # For over 65 group
-  admissions_diab |> filter(age_grp2 == "65+" & type == "e11_keto") |>  
-    create_rates(cats = "age_grp2", epop_total = 19500, sex = T),
-  # all ages by sex 
-  seccare_c3 |>  create_rates(cats = "type", epop_total = 100000, sex = T) |> 
-    select(-type) |>  
-    mutate(age_grp2 =  "All")) |> 
-  mutate(type = "e11_keto")
-
-
-seccare_c3_e10_final <- seccare_c3_e10 |> 
-  #Creating labels for chart
-  mutate(class1 = case_when(age_grp2 == 'All' & sex == '2' ~ 'Female - all ages',
-                            age_grp2 == '<25' & sex == '2' ~ 'Female - 0-24',
-                            age_grp2 == '25-44' & sex == '2' ~ 'Female - 25-44',
-                            age_grp2 == '45-64' & sex == '2' ~ 'Female - 45-64',
-                            age_grp2 == '65+' & sex == '2' ~ 'Female - 65+',
-                            age_grp2 == 'All' & sex == '1' ~ 'Male - all ages',
-                            age_grp2 == '<25' & sex == '1' ~ 'Male - 0-24',
-                            age_grp2 == '25-44' & sex == '1' ~ 'Male - 25-44',
-                            age_grp2 == '45-64' & sex == '1' ~ 'Male - 45-64',
-                            age_grp2 == '65+' & sex == '1' ~ 'Male - 65+')) |>  
-  make_year_labels(year_type = "financial") |>   # Relabeling years
-  rename(class2 = year) |> select(class2, class1, numerator, rate) |> 
-  mutate(type = "E10")
-
-seccare_c3_e11_final <- seccare_c3_e11 |> 
-  #Creating labels for chart
-  mutate(class1 = case_when(age_grp2 == 'All' & sex == '2' ~ 'Female - all ages',
-                            age_grp2 == '<25' & sex == '2' ~ 'Female - 0-24',
-                            age_grp2 == '25-44' & sex == '2' ~ 'Female - 25-44',
-                            age_grp2 == '45-64' & sex == '2' ~ 'Female - 45-64',
-                            age_grp2 == '65+' & sex == '2' ~ 'Female - 65+',
-                            age_grp2 == 'All' & sex == '1' ~ 'Male - all ages',
-                            age_grp2 == '<25' & sex == '1' ~ 'Male - 0-24',
-                            age_grp2 == '25-44' & sex == '1' ~ 'Male - 25-44',
-                            age_grp2 == '45-64' & sex == '1' ~ 'Male - 45-64',
-                            age_grp2 == '65+' & sex == '1' ~ 'Male - 65+')) |>  
-  make_year_labels(year_type = "financial") |>   # Relabeling years
-  rename(class2 = year) |> select(class2, class1, numerator, rate) |> 
-  mutate(type = "E11")
-
-#write_csv(seccare_c3, paste0(output, "/diabetes_secondarycare_chart3.csv))
-#Preserving chart 3 above which is ketoacidosis not split by type
-write_csv(seccare_c3_e10_final, paste0(output, "/diabetes_secondarycare_chart4.csv"))
-write_csv(seccare_c3_e11_final, paste0(output, "/diabetes_secondarycare_chart5.csv"))
+# 
+# ###############################################.
+# # Creating file for Secondary care section chart 1.
+# # Chart 1 - admissions for type one diabetes in main or any position split by sex
+# seccare_c1 <- admissions_diab |> 
+#   filter(type == "e10_main" | type == "e10_any") 
+# 
+# #Create totals for both sexes
+# seccare_c1_total <- seccare_c1 |> 
+#   group_by(year, age_grp, age_grp2, type) |>
+#   summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup() |>
+#   mutate(sex = "All")
+# 
+# # # Calculating rates for all and for each sex
+# seccare_c1_total <- seccare_c1_total |>  create_rates(cats = "type", epop_total = 200000, sex = T)
+# seccare_c1_sex <- seccare_c1 |>  create_rates(cats = "type", epop_total = 100000, sex = T)
+# 
+# # # Preparing file for chart
+# seccare_c1 <- rbind(seccare_c1_total, seccare_c1_sex) |>
+#   #Creating labels for chart
+#   mutate(class1 = case_when(type == "e10_main" & sex == "All" ~ "All - main diagnosis",
+#                             type == "e10_any" & sex == "All" ~ "All - any diagnosis",
+#                             type == "e10_main" & sex == "1" ~ "Male - main diagnosis",
+#                             type == "e10_main" & sex == "2" ~ "Female - main diagnosis",
+#                             type == "e10_any" & sex == "1" ~ "Male - any diagnosis",
+#                             type == "e10_any" & sex == "2" ~ "Female - any diagnosis")) |> 
+#   make_year_labels(year_type = "financial") |> #Relabeling years
+#   rename(class2 = year) |>  select(class2, class1, numerator, rate)
+#   
+# write_csv(seccare_c1, paste0(output, "/diabetes_secondarycare_chart1.csv"))
+# 
+# ###############################################.
+# # Creating file for Secondary care section chart 2.
+# #Chart 2 - admissions for type 2 diabetes in main or any position split by sex
+# seccare_c2 <- admissions_diab |> 
+#   filter(type == "e11_main" | type == "e11_any") 
+# 
+# #Create totals for both sexes
+# seccare_c2_total <- seccare_c2 |> 
+#   group_by(year, age_grp, age_grp2, type) |>
+#   summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup() |>
+#   mutate(sex = "All")
+# 
+# # # Calculating rates for all and for each sex
+# seccare_c2_total <- seccare_c2_total |>  create_rates(cats = "type", epop_total = 200000, sex = T)
+# seccare_c2_sex <- seccare_c2 |>  create_rates(cats = "type", epop_total = 100000, sex = T)
+# 
+# # # Preparing file for chart
+# seccare_c2 <- rbind(seccare_c2_total, seccare_c2_sex) |>
+#   #Creating labels for chart
+#   mutate(class1 = case_when(type == "e11_main" & sex == "All" ~ "All - main diagnosis",
+#                             type == "e11_any" & sex == "All" ~ "All - any diagnosis",
+#                             type == "e11_main" & sex == "1" ~ "Male - main diagnosis",
+#                             type == "e11_main" & sex == "2" ~ "Female - main diagnosis",
+#                             type == "e11_any" & sex == "1" ~ "Male - any diagnosis",
+#                             type == "e11_any" & sex == "2" ~ "Female - any diagnosis")) |> 
+#   make_year_labels(year_type = "financial") |> #Relabeling years
+#   rename(class2 = year) |>  select(class2, class1, numerator, rate)
+# 
+# write_csv(seccare_c2, paste0(output, "/diabetes_secondarycare_chart2.csv"))
+# 
+# ###############################################.
+# # Creating file for Secondary care section chart 3.
+# # ketoacidosis - splitting by type 1 and 2
+# seccare_c3_filtered <- admissions_diab |> 
+#   filter(type == "e10_keto") 
+# 
+# seccare_c3_total<- seccare_c3_filtered|> 
+#   group_by(sex, year, age_grp, age_grp2, type) |>
+#   summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup()
+# 
+# 
+# seccare_c3_e10 <- rbind( #calculating rates for each age group
+#   # For under 25 group group
+#   admissions_diab |>  filter(age_grp2 == "<25" & type == "e10_keto") |>  
+#     create_rates(cats = "age_grp2", epop_total = 27500, sex = T),
+#   # For 25 to 44 group
+#   admissions_diab |>  filter(age_grp2 == "25-44" & type == "e10_keto") |>  
+#     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
+#   # For 45 to 64 group
+#   admissions_diab |>  filter(age_grp2 == "45-64" & type == "e10_keto") |> 
+#     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
+#   # For over 65 group
+#   admissions_diab |> filter(age_grp2 == "65+" & type == "e10_keto") |>  
+#     create_rates(cats = "age_grp2", epop_total = 19500, sex = T),
+#   # all ages by sex 
+#   seccare_c3 |>  create_rates(cats = "type", epop_total = 100000, sex = T) |> 
+#     select(-type) |>  
+#     mutate(age_grp2 =  "All")) |> 
+#   mutate(type = "e10_keto")
+# 
+# seccare_c3_filtered <- admissions_diab |> 
+#   filter(type == "e11_keto") 
+# 
+# seccare_c3_total<- seccare_c3_filtered |> 
+#   group_by(sex, year, age_grp, age_grp2, type) |>
+#   summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup()
+# 
+# 
+# seccare_c3_e11 <- rbind( #calculating rates for each age group
+#   # For under 25 group group
+#   admissions_diab |>  filter(age_grp2 == "<25" & type == "e11_keto") |>  
+#     create_rates(cats = "age_grp2", epop_total = 27500, sex = T),
+#   # For 25 to 44 group
+#   admissions_diab |>  filter(age_grp2 == "25-44" & type == "e11_keto") |>  
+#     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
+#   # For 45 to 64 group
+#   admissions_diab |>  filter(age_grp2 == "45-64" & type == "e11_keto") |> 
+#     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
+#   # For over 65 group
+#   admissions_diab |> filter(age_grp2 == "65+" & type == "e11_keto") |>  
+#     create_rates(cats = "age_grp2", epop_total = 19500, sex = T),
+#   # all ages by sex 
+#   seccare_c3 |>  create_rates(cats = "type", epop_total = 100000, sex = T) |> 
+#     select(-type) |>  
+#     mutate(age_grp2 =  "All")) |> 
+#   mutate(type = "e11_keto")
+# 
+# 
+# seccare_c3_e10_final <- seccare_c3_e10 |> 
+#   #Creating labels for chart
+#   mutate(class1 = case_when(age_grp2 == 'All' & sex == '2' ~ 'Female - all ages',
+#                             age_grp2 == '<25' & sex == '2' ~ 'Female - 0-24',
+#                             age_grp2 == '25-44' & sex == '2' ~ 'Female - 25-44',
+#                             age_grp2 == '45-64' & sex == '2' ~ 'Female - 45-64',
+#                             age_grp2 == '65+' & sex == '2' ~ 'Female - 65+',
+#                             age_grp2 == 'All' & sex == '1' ~ 'Male - all ages',
+#                             age_grp2 == '<25' & sex == '1' ~ 'Male - 0-24',
+#                             age_grp2 == '25-44' & sex == '1' ~ 'Male - 25-44',
+#                             age_grp2 == '45-64' & sex == '1' ~ 'Male - 45-64',
+#                             age_grp2 == '65+' & sex == '1' ~ 'Male - 65+')) |>  
+#   make_year_labels(year_type = "financial") |>   # Relabeling years
+#   rename(class2 = year) |> select(class2, class1, numerator, rate) |> 
+#   mutate(type = "E10")
+# 
+# seccare_c3_e11_final <- seccare_c3_e11 |> 
+#   #Creating labels for chart
+#   mutate(class1 = case_when(age_grp2 == 'All' & sex == '2' ~ 'Female - all ages',
+#                             age_grp2 == '<25' & sex == '2' ~ 'Female - 0-24',
+#                             age_grp2 == '25-44' & sex == '2' ~ 'Female - 25-44',
+#                             age_grp2 == '45-64' & sex == '2' ~ 'Female - 45-64',
+#                             age_grp2 == '65+' & sex == '2' ~ 'Female - 65+',
+#                             age_grp2 == 'All' & sex == '1' ~ 'Male - all ages',
+#                             age_grp2 == '<25' & sex == '1' ~ 'Male - 0-24',
+#                             age_grp2 == '25-44' & sex == '1' ~ 'Male - 25-44',
+#                             age_grp2 == '45-64' & sex == '1' ~ 'Male - 45-64',
+#                             age_grp2 == '65+' & sex == '1' ~ 'Male - 65+')) |>  
+#   make_year_labels(year_type = "financial") |>   # Relabeling years
+#   rename(class2 = year) |> select(class2, class1, numerator, rate) |> 
+#   mutate(type = "E11")
+# 
+# #write_csv(seccare_c3, paste0(output, "/diabetes_secondarycare_chart3.csv))
+# #Preserving chart 3 above which is ketoacidosis not split by type
+# write_csv(seccare_c3_e10_final, paste0(output, "/diabetes_secondarycare_chart4.csv"))
+# write_csv(seccare_c3_e11_final, paste0(output, "/diabetes_secondarycare_chart5.csv"))
 
 ###############################################.
 ## Part 3 - Deaths data ----
@@ -321,7 +329,7 @@ deaths_diab_e10 <- deaths_diab_rates |>
 
 #Create type 2 diabetes data
 deaths_diab_e11 <- deaths_diab_rates |> 
-  filter(type == "main_diag_e11" | type == "any_diag_e11")
+  filter(type == "main_diag_e11" | type == "any_diag_e11") |> 
   #Creating labels for chart
   mutate(class1 = case_when(type == 'main_diag_e11' & sex == 'All' ~ 'All - Type 2 - Underlying',
                           type == "main_diag_e11" & sex == "1" ~ "Male - Type 2 - Underlying",
@@ -332,7 +340,7 @@ deaths_diab_e11 <- deaths_diab_rates |>
   rename(class2 = year) |> select(class2, class1, numerator, rate)
 
 write_csv(deaths_diab_e10, paste0(output, "/diabetes_mortality_chart1.csv"))
-write_csv(deaths_diab_e10, paste0(output, "/diabetes_mortality_chart2.csv"))
+write_csv(deaths_diab_e11, paste0(output, "/diabetes_mortality_chart2.csv"))
 
 
 ##END

--- a/Diabetes update.R
+++ b/Diabetes update.R
@@ -11,30 +11,27 @@
 # load packages and functions required to run all commands
 source("1.analysis_functions.R")
 
-# change automatically depending if you are using R server or R desktop
-if (sessionInfo()$platform %in% c("x86_64-redhat-linux-gnu (64-bit)", "x86_64-pc-linux-gnu (64-bit)")) {
-  output <- "/PHI_conf/ScotPHO/Website/Topics/Diabetes/Data/December_2022_updates/"
+library(stringr)
+
+# set files paths. folder will have to be created for newest year's data
+
+  output <- "/PHI_conf/ScotPHO/Website/Topics/Diabetes/Data/Mar25"
   lookups <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Population/"
-  
-} else {
-  output <- "//stats/ScotPHO/Website/Topics/Diabetes/Data/December_2022_updates/"
-  lookups <- "//stats/ScotPHO/Profiles/Data/Lookups/Population/"
-}
 
 ###############################################.
 ## Part 1 - Population files ----
 ###############################################.
-population <- readRDS(paste0(lookups, "CA_pop_allages_SR.rds")) %>% 
+population <- readRDS(paste0(lookups, "CA_pop_allages_SR.rds")) |> 
   filter(code == 'S00000001') %>%  # Selecting only Scotland level
-  add_epop() %>% # Add European Standard Populations for each age group
+  add_epop() |>  # Add European Standard Populations for each age group
   # Create required age groups  (<25, 25-44, 45-64, 65+)
   mutate(age_grp2 = case_when(between(age_grp, 1, 5) ~ "<25",
                           between(age_grp, 6, 9) ~ "25-44",
                           between(age_grp, 10, 13) ~ "45-64",
                           between(age_grp, 14, 19) ~ "65+"),
-  sex = as.character(sex_grp)) %>% 
-  group_by(year, sex, age_grp, age_grp2) %>% #aggregating
-  summarize_at(c("denominator", "epop"), sum, na.rm = TRUE) %>% ungroup()
+  sex = as.character(sex_grp)) |> 
+  group_by(year, sex, age_grp, age_grp2) |> #aggregating
+  summarize_at(c("denominator", "epop"), sum, na.rm = TRUE) |>  ungroup()
 
 ###############################################.
 ## Part 2 - Hospital admissions data ----
@@ -50,93 +47,176 @@ channel <- suppressWarnings(dbConnect(odbc(),  dsn="SMRA",
 # and if there is a diagnosis of ketoacidosis. It should take ~ 5 mins to run.
 # Create one record per CIS selecting the admission date and personal/geographical details from 
 # the first episode of the CIS, the latest discharge date of the CIS, ensuring all required diagnoses are captured.
-admissions_diab <- tbl_df(dbGetQuery(channel, statement=
- "SELECT sum(z.diab_main) diab_main, sum(z.diab_keto) diab_keto, sum(z.diabetes) diabetes,
+admissions_diab <- tibble::as_tibble(dbGetQuery(channel, statement=
+"SELECT sum(z.E10_main) E10_main, sum(z.E11_main) E11_main, sum(z.other_main) other_main, sum(z.E10_any) E10_any,
+ sum(z.E11_any) E11_any, sum(z.other_any) other_any, sum(z.E10_keto) E10_keto, sum(z.E11_keto) E11_keto,
     z.year, z.age, z.sex
   FROM (SELECT distinct link_no | | cis_marker CIS, max(age_in_years) age, max(sex) sex, 
       max(CASE WHEN extract(month from discharge_date) > 3 THEN extract(year from discharge_date) 
             ELSE extract(year from discharge_date) -1 END) as year, 
-      max(CASE WHEN regexp_like(main_condition, 'E1[01234]') then 1 else 0 end) diab_main, 
-      max(CASE WHEN regexp_like(main_condition, 'E101|E111|E121|E131|E141') then 1 else 0 end) diab_keto, 
+      max(CASE WHEN regexp_like(main_condition, 'E10') then 1 else 0 end) E10_main,
+      max(CASE WHEN regexp_like(main_condition, 'E11') then 1 else 0 end) E11_main,
+      max(CASE WHEN regexp_like(main_condition, 'E1[234]') then 1 else 0 end) other_main,
+      max(CASE WHEN regexp_like(main_condition, 'E10') then 1 else 0 end) E10_keto,
+      max(CASE WHEN regexp_like(main_condition, 'E11') then 1 else 0 end) E11_keto,
       max(CASE WHEN regexp_like(main_condition || other_condition_1 || other_condition_2
-            || other_condition_3 || other_condition_4 || other_condition_5, 'E1[01234]')
-            THEN 1 ELSE 0 END) diabetes 
+            || other_condition_3 || other_condition_4 || other_condition_5, 'E10')
+            THEN 1 ELSE 0 END) E10_any, 
+      max(CASE WHEN regexp_like(main_condition || other_condition_1 || other_condition_2
+            || other_condition_3 || other_condition_4 || other_condition_5, 'E11')
+            THEN 1 ELSE 0 END) E11_any,
+      max(CASE WHEN regexp_like(main_condition || other_condition_1 || other_condition_2
+            || other_condition_3 || other_condition_4 || other_condition_5, 'E1[234]')
+            THEN 1 ELSE 0 END) other_any 
     FROM ANALYSIS.SMR01_PI 
-    WHERE discharge_date between '1 April 2011' and '31 March 2022'
+    WHERE discharge_date between '1 April 2011' and '31 March 2024'
       and hbtreat_currentdate is not null 
       and sex in ('1','2') 
       and regexp_like(main_condition || other_condition_1 || other_condition_2
             || other_condition_3 || other_condition_4 || other_condition_5, 'E1[01234]') 
     GROUP BY link_no | | cis_marker) z  
- GROUP BY z.year, z.age, z.sex")) %>% 
-  setNames(tolower(names(.)))  #variables to lower case
+ GROUP BY z.year, z.age, z.sex")) |> 
+  janitor::clean_names()  #variables to lower case
+
 
 #Age groups and aggregating by sex, year and age group
-admissions_diab <- admissions_diab %>% create_agegroups() %>% 
+admissions_diab <- admissions_diab |> create_agegroups() |>  
   mutate(age_grp2 = case_when(between(age_grp, 1, 5) ~ "<25",
                               between(age_grp, 6, 9) ~ "25-44",
                               between(age_grp, 10, 13) ~ "45-64",
-                              between(age_grp, 14, 19) ~ "65+")) %>% 
-  group_by(year, sex, age_grp, age_grp2) %>% 
-  summarize_at(c("diabetes", "diab_main", "diab_keto"), sum, na.rm = T) %>% 
+                              between(age_grp, 14, 19) ~ "65+")) |> 
+  group_by(year, sex, age_grp, age_grp2) |> 
+  summarize_at(c("e10_main", "e11_main", "other_main", "e10_keto", "e11_keto", "e10_any", "e11_any", "other_any"), sum, na.rm = T) |>  
   #From wide to long format
-  gather(type, numerator, -c(year, sex, age_grp, age_grp2)) %>% ungroup()
+  gather(type, numerator, -c(year, sex, age_grp, age_grp2)) |>  ungroup()
 
 #Bringing population information to calculate rates.
 admissions_diab <- left_join(admissions_diab, population, 
-                             by = c("year", "sex", "age_grp", "age_grp2")) %>% 
+                             by = c("year", "sex", "age_grp", "age_grp2")) |>  
   add_epop() #adding European population for rate calculation
 
-saveRDS(admissions_diab, paste0(output, "diabetes_admissions_basefile.rds"))
-admissions_diab <- readRDS(paste0(output, "diabetes_admissions_basefile.rds")) 
+saveRDS(admissions_diab, file = paste0(output, "/diabetes_admissions_basefile.rds"))
+admissions_diab <- readRDS(paste0(output, "/diabetes_admissions_basefile.rds")) 
 
 ###############################################.
 # Creating file for Secondary care section chart 1.
-#Creating totals for both sexes 
-seccare_c1_total <- admissions_diab %>%  group_by(year, age_grp, age_grp2, type) %>% 
-  summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) %>% ungroup() %>% 
+# Chart 1 - admissions for type one diabetes in main or any position split by sex
+seccare_c1 <- admissions_diab |> 
+  filter(type == "e10_main" | type == "e10_any") 
+
+#Create totals for both sexes
+seccare_c1_total <- seccare_c1 |> 
+  group_by(year, age_grp, age_grp2, type) |>
+  summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup() |>
   mutate(sex = "All")
 
-# Calculating rates for all and for each sex
-seccare_c1_total <- seccare_c1_total %>% create_rates(cats = "type", epop_total = 200000, sex = T)
+# # Calculating rates for all and for each sex
+seccare_c1_total <- seccare_c1_total |>  create_rates(cats = "type", epop_total = 200000, sex = T)
+seccare_c1_sex <- seccare_c1 |>  create_rates(cats = "type", epop_total = 100000, sex = T)
 
-seccare_c1_sex <- admissions_diab %>% create_rates(cats = "type", epop_total = 100000, sex = T)
-
-# Preparing file for chart
-seccare_c1 <- rbind(seccare_c1_total, seccare_c1_sex) %>% 
-  filter(type != "diab_keto") %>% #ketoacidosis is shown in the second chart
+# # Preparing file for chart
+seccare_c1 <- rbind(seccare_c1_total, seccare_c1_sex) |>
   #Creating labels for chart
-  mutate(class1 = case_when(type == 'diab_main' & sex == 'All' ~ 'All - main diagnosis',
-      type == 'diab_main' & sex == '2' ~ 'Female - main diagnosis',
-      type == 'diab_main' & sex == '1' ~ 'Male - main diagnosis',
-      type == 'diabetes' & sex == 'All' ~ 'All - any diagnosis',
-      type == 'diabetes' & sex == '2' ~ 'Female - any diagnosis',
-      type == 'diabetes' & sex == '1' ~ 'Male - any diagnosis')) %>% 
-  make_year_labels(year_type = "financial") %>%  # Relabeling years
-  rename(class2 = year) %>% select(class2, class1, numerator, rate)
-
-write_csv(seccare_c1, paste0(output, "diabetes_secondarycare_chart1.csv"))
+  mutate(class1 = case_when(type == "e10_main" & sex == "All" ~ "All - main diagnosis",
+                            type == "e10_any" & sex == "All" ~ "All - any diagnosis",
+                            type == "e10_main" & sex == "1" ~ "Male - main diagnosis",
+                            type == "e10_main" & sex == "2" ~ "Female - main diagnosis",
+                            type == "e10_any" & sex == "1" ~ "Male - any diagnosis",
+                            type == "e10_any" & sex == "2" ~ "Female - any diagnosis")) |> 
+  make_year_labels(year_type = "financial") |> #Relabeling years
+  rename(class2 = year) |>  select(class2, class1, numerator, rate)
+  
+write_csv(seccare_c1, paste0(output, "/diabetes_secondarycare_chart1.csv"))
 
 ###############################################.
 # Creating file for Secondary care section chart 2.
-seccare_c2 <- rbind( #calculating rates for each age group
+#Chart 2 - admissions for type 2 diabetes in main or any position split by sex
+seccare_c2 <- admissions_diab |> 
+  filter(type == "e11_main" | type == "e11_any") 
+
+#Create totals for both sexes
+seccare_c2_total <- seccare_c2 |> 
+  group_by(year, age_grp, age_grp2, type) |>
+  summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup() |>
+  mutate(sex = "All")
+
+# # Calculating rates for all and for each sex
+seccare_c2_total <- seccare_c2_total |>  create_rates(cats = "type", epop_total = 200000, sex = T)
+seccare_c2_sex <- seccare_c2 |>  create_rates(cats = "type", epop_total = 100000, sex = T)
+
+# # Preparing file for chart
+seccare_c2 <- rbind(seccare_c2_total, seccare_c2_sex) |>
+  #Creating labels for chart
+  mutate(class1 = case_when(type == "e11_main" & sex == "All" ~ "All - main diagnosis",
+                            type == "e11_any" & sex == "All" ~ "All - any diagnosis",
+                            type == "e11_main" & sex == "1" ~ "Male - main diagnosis",
+                            type == "e11_main" & sex == "2" ~ "Female - main diagnosis",
+                            type == "e11_any" & sex == "1" ~ "Male - any diagnosis",
+                            type == "e11_any" & sex == "2" ~ "Female - any diagnosis")) |> 
+  make_year_labels(year_type = "financial") |> #Relabeling years
+  rename(class2 = year) |>  select(class2, class1, numerator, rate)
+
+write_csv(seccare_c2, paste0(output, "/diabetes_secondarycare_chart2.csv"))
+
+###############################################.
+# Creating file for Secondary care section chart 3.
+# ketoacidosis - splitting by type 1 and 2
+seccare_c3_filtered <- admissions_diab |> 
+  filter(type == "e10_keto") 
+
+seccare_c3_total<- seccare_c3_filtered|> 
+  group_by(sex, year, age_grp, age_grp2, type) |>
+  summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup()
+
+
+seccare_c3_e10 <- rbind( #calculating rates for each age group
   # For under 25 group group
-  admissions_diab %>% filter(age_grp2 == "<25" & type == "diab_keto") %>% 
+  admissions_diab |>  filter(age_grp2 == "<25" & type == "e10_keto") |>  
     create_rates(cats = "age_grp2", epop_total = 27500, sex = T),
   # For 25 to 44 group
-  admissions_diab %>% filter(age_grp2 == "25-44" & type == "diab_keto") %>% 
+  admissions_diab |>  filter(age_grp2 == "25-44" & type == "e10_keto") |>  
     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
   # For 45 to 64 group
-  admissions_diab %>% filter(age_grp2 == "45-64" & type == "diab_keto") %>% 
+  admissions_diab |>  filter(age_grp2 == "45-64" & type == "e10_keto") |> 
     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
   # For over 65 group
-  admissions_diab %>% filter(age_grp2 == "65+" & type == "diab_keto") %>% 
+  admissions_diab |> filter(age_grp2 == "65+" & type == "e10_keto") |>  
     create_rates(cats = "age_grp2", epop_total = 19500, sex = T),
   # all ages by sex 
-  seccare_c1_sex %>% filter(type == "diab_keto") %>% select(-type) %>% 
-    mutate(age_grp2 =  "All")) 
+  seccare_c3 |>  create_rates(cats = "type", epop_total = 100000, sex = T) |> 
+    select(-type) |>  
+    mutate(age_grp2 =  "All")) |> 
+  mutate(type = "e10_keto")
 
-seccare_c2 <- seccare_c2 %>% 
+seccare_c3_filtered <- admissions_diab |> 
+  filter(type == "e11_keto") 
+
+seccare_c3_total<- seccare_c3_filtered |> 
+  group_by(sex, year, age_grp, age_grp2, type) |>
+  summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup()
+
+
+seccare_c3_e11 <- rbind( #calculating rates for each age group
+  # For under 25 group group
+  admissions_diab |>  filter(age_grp2 == "<25" & type == "e11_keto") |>  
+    create_rates(cats = "age_grp2", epop_total = 27500, sex = T),
+  # For 25 to 44 group
+  admissions_diab |>  filter(age_grp2 == "25-44" & type == "e11_keto") |>  
+    create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
+  # For 45 to 64 group
+  admissions_diab |>  filter(age_grp2 == "45-64" & type == "e11_keto") |> 
+    create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
+  # For over 65 group
+  admissions_diab |> filter(age_grp2 == "65+" & type == "e11_keto") |>  
+    create_rates(cats = "age_grp2", epop_total = 19500, sex = T),
+  # all ages by sex 
+  seccare_c3 |>  create_rates(cats = "type", epop_total = 100000, sex = T) |> 
+    select(-type) |>  
+    mutate(age_grp2 =  "All")) |> 
+  mutate(type = "e11_keto")
+
+
+seccare_c3_e10_final <- seccare_c3_e10 |> 
   #Creating labels for chart
   mutate(class1 = case_when(age_grp2 == 'All' & sex == '2' ~ 'Female - all ages',
                             age_grp2 == '<25' & sex == '2' ~ 'Female - 0-24',
@@ -147,23 +227,53 @@ seccare_c2 <- seccare_c2 %>%
                             age_grp2 == '<25' & sex == '1' ~ 'Male - 0-24',
                             age_grp2 == '25-44' & sex == '1' ~ 'Male - 25-44',
                             age_grp2 == '45-64' & sex == '1' ~ 'Male - 45-64',
-                            age_grp2 == '65+' & sex == '1' ~ 'Male - 65+')) %>% 
-  make_year_labels(year_type = "financial") %>%  # Relabeling years
-  rename(class2 = year) %>% select(class2, class1, numerator, rate)
+                            age_grp2 == '65+' & sex == '1' ~ 'Male - 65+')) |>  
+  make_year_labels(year_type = "financial") |>   # Relabeling years
+  rename(class2 = year) |> select(class2, class1, numerator, rate) |> 
+  mutate(type = "E10")
 
-write_csv(seccare_c2, paste0(output, "diabetes_secondarycare_chart2.csv"))
+seccare_c3_e11_final <- seccare_c3_e11 |> 
+  #Creating labels for chart
+  mutate(class1 = case_when(age_grp2 == 'All' & sex == '2' ~ 'Female - all ages',
+                            age_grp2 == '<25' & sex == '2' ~ 'Female - 0-24',
+                            age_grp2 == '25-44' & sex == '2' ~ 'Female - 25-44',
+                            age_grp2 == '45-64' & sex == '2' ~ 'Female - 45-64',
+                            age_grp2 == '65+' & sex == '2' ~ 'Female - 65+',
+                            age_grp2 == 'All' & sex == '1' ~ 'Male - all ages',
+                            age_grp2 == '<25' & sex == '1' ~ 'Male - 0-24',
+                            age_grp2 == '25-44' & sex == '1' ~ 'Male - 25-44',
+                            age_grp2 == '45-64' & sex == '1' ~ 'Male - 45-64',
+                            age_grp2 == '65+' & sex == '1' ~ 'Male - 65+')) |>  
+  make_year_labels(year_type = "financial") |>   # Relabeling years
+  rename(class2 = year) |> select(class2, class1, numerator, rate) |> 
+  mutate(type = "E11")
+
+#write_csv(seccare_c3, paste0(output, "/diabetes_secondarycare_chart3.csv))
+#Preserving chart 3 above which is ketoacidosis not split by type
+write_csv(seccare_c3_e10_final, paste0(output, "/diabetes_secondarycare_chart4.csv"))
+write_csv(seccare_c3_e11_final, paste0(output, "/diabetes_secondarycare_chart5.csv"))
 
 ###############################################.
 ## Part 3 - Deaths data ----
 ###############################################.
-# Scottish resident deaths due to diabetes (any position) and valid sex recorded. 
-# Creating variable with ones where it was the main cause. 
-deaths_diab <- tbl_df(
+
+deaths_diab <- tibble::as_tibble(
   dbGetQuery(channel, statement=
-  "SELECT year_of_registration year, sex, age, count(*) all_diag,  
-    sum(case when regexp_like(UNDERLYING_CAUSE_OF_DEATH, 'E1[01234]') then 1 else 0 end) main_diag 
+               "SELECT year_of_registration year, sex, age,  
+    sum(case when regexp_like(UNDERLYING_CAUSE_OF_DEATH, 'E10') then 1 else 0 end) main_diag_e10,
+    sum(case when regexp_like(UNDERLYING_CAUSE_OF_DEATH, 'E11') then 1 else 0 end) main_diag_e11,
+    sum(case when regexp_like(UNDERLYING_CAUSE_OF_DEATH || cause_of_death_code_0 ||
+      cause_of_death_code_1 ||  cause_of_death_code_2 ||  cause_of_death_code_3 || 
+      cause_of_death_code_4 ||  cause_of_death_code_5 ||  cause_of_death_code_6 || 
+      cause_of_death_code_7 ||  cause_of_death_code_8 ||  cause_of_death_code_9,
+      'E10') then 1 else 0 end) any_diag_e10,
+    sum(case when regexp_like(UNDERLYING_CAUSE_OF_DEATH || cause_of_death_code_0 ||
+      cause_of_death_code_1 ||  cause_of_death_code_2 ||  cause_of_death_code_3 || 
+      cause_of_death_code_4 ||  cause_of_death_code_5 ||  cause_of_death_code_6 || 
+      cause_of_death_code_7 ||  cause_of_death_code_8 ||  cause_of_death_code_9,
+      'E11') then 1 else 0 end) any_diag_e11  
   FROM ANALYSIS.GRO_DEATHS_C 
-  WHERE year_of_registration between 2011 and 2021 
+  WHERE year_of_registration between 2011 and 2023
     and country_of_residence= 'XS' 
     and sex <> 9 
     and regexp_like(UNDERLYING_CAUSE_OF_DEATH || cause_of_death_code_0 ||
@@ -171,13 +281,14 @@ deaths_diab <- tbl_df(
       cause_of_death_code_4 ||  cause_of_death_code_5 ||  cause_of_death_code_6 || 
       cause_of_death_code_7 ||  cause_of_death_code_8 ||  cause_of_death_code_9,
       'E1[01234]') 
-  GROUP BY year_of_registration, sex, age ")) %>%
-  setNames(tolower(names(.)))  #variables to lower case
-  
+  GROUP BY year_of_registration, sex, age ")) |> 
+  janitor::clean_names()  #variables to lower case
+
+
 # Creating age_groups and aggregating by them.
-deaths_diab <- deaths_diab %>% create_agegroups() %>% group_by(year, sex, age_grp) %>% 
-  summarize_at(c("all_diag", "main_diag"), sum, na.rm = T) %>%
-  gather(type, numerator, -c(year, sex, age_grp)) %>%  #From wide to long format
+deaths_diab <- deaths_diab |>  create_agegroups() |>  group_by(year, sex, age_grp) |> 
+  summarize_at(c("any_diag_e10", "any_diag_e11", "main_diag_e10", "main_diag_e11"), sum, na.rm = T) |> 
+  gather(type, numerator, -c(year, sex, age_grp)) |>   #From wide to long format
   ungroup()
 
 #Bringing population information to calculate rates.
@@ -185,25 +296,43 @@ deaths_diab <- left_join(deaths_diab, population,
                         by = c("year", "sex", "age_grp"))
 
 # Creating totals for both sexes and adding them to the basefile.
-deaths_totals <- deaths_diab %>% group_by(year, age_grp, age_grp2, type) %>% 
-  summarize_at(c("numerator", "denominator", "epop"), sum, na.rm = T) %>% ungroup() %>% 
-  mutate(sex = "All") %>% 
+deaths_totals <- deaths_diab |> group_by(year, age_grp, age_grp2, type) |> 
+  summarize_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup() |> 
+  mutate(sex = "All") |> 
   create_rates(cats = c("type", "sex"), epop_total = 200000, sex = T)
   
 #Calculating rates for each sex
-deaths_diab_sex <- deaths_diab %>% 
+deaths_diab_sex <- deaths_diab |> 
   create_rates(cats = c("type", "sex"), epop_total = 100000, sex = T)
 
-deaths_diab_rates <- rbind(deaths_diab_sex, deaths_totals) %>% 
-  #Creating labels for chart
-  mutate(class1 = case_when(type == 'main_diag' & sex == 'All' ~ 'All - underlying',
-                            type == 'main_diag' & sex == '2' ~ 'Female - underlying',
-                            type == 'main_diag' & sex == '1' ~ 'Male - underlying',
-                            type == 'all_diag' & sex == 'All' ~ 'All - contributory',
-                            type == 'all_diag' & sex == '2' ~ 'Female - contributory',
-                            type == 'all_diag' & sex == '1' ~ 'Male - contributory')) %>% 
-  rename(class2 = year) %>% select(class2, class1, numerator, rate)
+deaths_diab_rates <- rbind(deaths_diab_sex, deaths_totals)
 
-write_csv(deaths_diab_rates, paste0(output, "diabetes_mortality_chart1.csv"))
+#Create type 1 diabetes data
+deaths_diab_e10 <- deaths_diab_rates |> 
+  filter(type == "main_diag_e10" | type == "any_diag_e10") |> 
+  #Creating labels for chart
+  mutate(class1 = case_when(type == 'main_diag_e10' & sex == 'All' ~ 'All - Type 1 - Underlying',
+                            type == "main_diag_e10" & sex == "1" ~ "Male - Type 1 - Underlying",
+                            type == "main_diag_e10" & sex == "2" ~ "Female - Type 1 - Underlying",
+                            type == 'any_diag_e10' & sex == 'All' ~ 'All - Type 1 - Contributory',
+                            type == "any_diag_e10" & sex == "1" ~ "Male - Type 1 - Contributory",
+                            type == "any_diag_e10" & sex == "2" ~ "Female - Type 1 - Contributory")) |> 
+  rename(class2 = year) |> select(class2, class1, numerator, rate)
+
+#Create type 2 diabetes data
+deaths_diab_e11 <- deaths_diab_rates |> 
+  filter(type == "main_diag_e11" | type == "any_diag_e11")
+  #Creating labels for chart
+  mutate(class1 = case_when(type == 'main_diag_e11' & sex == 'All' ~ 'All - Type 2 - Underlying',
+                          type == "main_diag_e11" & sex == "1" ~ "Male - Type 2 - Underlying",
+                          type == "main_diag_e11" & sex == "2" ~ "Female - Type 2 - Underlying",
+                          type == 'any_diag_e11' & sex == 'All' ~ 'All - Type 2 - Contributory',
+                          type == "any_diag_e11" & sex == "1" ~ "Male - Type 2 - Contributory",
+                          type == "any_diag_e11" & sex == "2" ~ "Female - Type 2 - Contributory")) |> 
+  rename(class2 = year) |> select(class2, class1, numerator, rate)
+
+write_csv(deaths_diab_e10, paste0(output, "/diabetes_mortality_chart1.csv"))
+write_csv(deaths_diab_e10, paste0(output, "/diabetes_mortality_chart2.csv"))
+
 
 ##END

--- a/Diabetes update.R
+++ b/Diabetes update.R
@@ -11,6 +11,8 @@
 # load packages and functions required to run all commands
 source("1.analysis_functions.R")
 library(stringr)
+library(purrr)
+library(janitor)
 
 # set files paths. folder will have to be created for newest year's data
 
@@ -48,245 +50,116 @@ admissions_diab_test <- tibble::as_tibble(dbGetQuery(channel, statement =
 other_condition_3, other_condition_4, other_condition_5, discharge_date, uri, cis_marker, link_no
 FROM ANALYSIS.SMR01_PI
 WHERE(
-discharge_date between '1 January 2024' and '31 March 2024'
+discharge_date between '1 April 2011' and '31 March 2024'
 and hbtreat_currentdate is not null
 and sex in ('1', '2')
 and regexp_like(main_condition || other_condition_1 || other_condition_2
             || other_condition_3 || other_condition_4 || other_condition_5, 'E1[01234]'))
-ORDER BY link_no, cis_marker, discharge_date, uri"))
+ORDER BY link_no, cis_marker, discharge_date, uri")) |> 
+  janitor::clean_names() #names to lower case
 
-#Tweak columns for easier interpretation e.g. change sex from numeric to character, 
-#Generate new columns identifying diabetes type, presence of ketoacidosis in admission, and whether the admission
-#was primarily due to diabetes or not
+# Identify diagnosis columns by name
+diag_cols <- names(admissions_diab_test)[3:8] 
 
+#Tidying up the data and creating some variables based on conditions present in admission and their position
 admissions_diab <- admissions_diab_test |> 
-  janitor::clean_names() |> #convert variable names to lower case
-  mutate(fin_year = phsmethods::extract_fin_year(discharge_date)) |>    #convert the date of discharge into a financial year
-  rowwise() |> #needed for mutating multiple cols at once
-  mutate(year = as.numeric(substr(fin_year, 1, 4)),
-         age = age_in_years, #rename to match analysis function
-         # sex = case_when(sex == 1 ~ "Male", #converts sex from numeric to string
-         #                 sex == 2 ~ "Female"),
-         diab_keto = if_else(any(stringr::str_detect(c_across(3:8), 'E101|E111|E121|E131|E141'), na.rm = TRUE), 1, 0), #searches all condition spaces for diabetic ketoacidosis and flags if found
-         diab_type = case_when(
-           any(str_detect(c_across(3:8), '^E10'), na.rm = TRUE) ~ "Type 1", #populates diab_type column with the diabetes type based on all diagnosis columns
-           any(str_detect(c_across(3:8), '^E11'), na.rm = TRUE) ~ "Type 2",
-           TRUE ~ "Other Diabetes"),
-         diab_main_flag = case_when(str_detect(main_condition, "E1[01234]") ~ "Main Position", TRUE ~ "Any Position")) |>  #identifies whether diabetes was the primary cause of admission
-  ungroup() 
-
-#Aggregating by link_no and cis to prevent duplication of stays
-admissions_diab_1.5 <- admissions_diab |> 
-  distinct(link_no, cis_marker, .keep_all = TRUE)
+  distinct(link_no, cis_marker, .keep_all = TRUE) |> #Aggregating by link_no and cis to prevent duplication of stays
+  mutate(
+    fin_year = phsmethods::extract_fin_year(discharge_date),  #convert the date of discharge into a financial year
+    year = as.numeric(substr(fin_year, 1, 4))) |>  #keep first year of fy
+  mutate(diab_keto = pmap_int(select(cur_data(), all_of(diag_cols)), function(...) { #using purrr for rowwise operations as it's more efficient
+      codes <- c(...)
+      if (any(str_detect(codes, 'E101|E111|E121|E131|E141'), na.rm = TRUE)) 1 else 0}), #searches all condition spaces for diabetic ketoacidosis and flags if found
+      diab_type = pmap_chr(select(cur_data(), all_of(diag_cols)), function(...) {
+      codes <- c(...)
+      case_when(
+        any(str_detect(codes, '^E10'), na.rm = TRUE) ~ "Type 1",
+        any(str_detect(codes, '^E11'), na.rm = TRUE) ~ "Type 2",
+        TRUE ~ "Other Diabetes")}), #Creating a diab_type column with the diabetes type based on all diagnosis columns
+    diab_main_flag = case_when(
+      str_detect(main_condition, "E1[01234]") ~ "Main Position",
+      TRUE ~ "Any Position")) |>  #Creating a flag to distinguish between admissions primarily due to diabetes and all admissions in diabetes sufferers
+  rename(age = age_in_years)
 
 #Aggregating data by age group and other categories created
-admissions_diab_2 <- admissions_diab_1.5 |> create_agegroups() |>  
-  group_by(sex, year, diab_keto, diab_type, diab_main_flag, age_grp) |> #counting number of admissions for each category.
+admissions_diab<- admissions_diab |> 
+  create_agegroups() |>  
+  group_by(sex, year, diab_keto, diab_type, diab_main_flag, age_grp, fin_year) |> #counting number of admissions for each category.
   summarise(numerator = n(), .groups = "drop") |> 
-  complete(sex, year, diab_keto, diab_type, diab_main_flag, age_grp, fill = list(numerator = 0)) |>  #filling in blank categories with 0 admissions
+  complete(sex, year, fin_year, diab_keto, diab_type, diab_main_flag, age_grp, fill = list(numerator = 0)) |>  #filling in blank categories with 0 admissions
   mutate(age_grp2 = case_when(between(age_grp, 1, 5) ~ "<25",
                                 between(age_grp, 6, 9) ~ "25-44",
                                 between(age_grp, 10, 13) ~ "45-64",
                                 between(age_grp, 14, 19) ~ "65+")) 
 
+#Adding keto acidosis as a type of admission alongside main/any
+admissions_diab_keto <- admissions_diab |> 
+  filter(diab_keto == 1) |> 
+  select(-diab_keto) |> 
+  mutate(diab_main_flag = "Diabetic Ketoacidosis") |> 
+  group_by(sex, year, fin_year, diab_type, diab_main_flag, age_grp, age_grp2) |> 
+  summarise(numerator = sum(numerator), .groups = "drop")
+
+#Appending back on to data - so some redundancy if the patient was a type 1 diabetes admission for ketoacidosis. 
+admissions_diab <- admissions_diab |> 
+  filter(diab_keto == 0) |> 
+  select(-diab_keto)
+
+admissions_diab <- rbind(admissions_diab, admissions_diab_keto)
 
 #Bringing population information to calculate rates.
-admissions_diab_3 <- left_join(admissions_diab_2, population, 
+admissions_diab <- left_join(admissions_diab, population, 
                              by = c("year", "sex", "age_grp", "age_grp2")) |>  
-  add_epop() |> #adding European population for rate calculation 
-  group_by(sex, year, diab_keto, diab_type, diab_main_flag, age_grp2) |> 
-    summarise(across(c(numerator, denominator, epop), sum), .groups = "drop") 
+  add_epop() #adding European population for rate calculation 
 
-# #Aggregate figures for males and females to get all sexes
-# all_sexes <- admissions_diab_3 |> #combining the data for males and females to get a count for both sexes combined
-#   group_by(year, diab_keto, diab_type, diab_main_flag, age_grp2) |> 
-#   summarise(numerator = sum(numerator), denominator = sum(denominator), epop = sum(epop), .groups = "drop") |> 
-#   mutate(sex = "All") 
-# 
-# admissions_diab_2 <- rbind(admissions_diab_2, all_sexes) #appending data for both sexes onto sex-split data
-# 
+#Aggregate figures for males and females to get all sexes
+all_sexes <- admissions_diab |> #combining the data for males and females to get a count for both sexes combined
+  group_by(year, fin_year, diab_type, diab_main_flag, age_grp, age_grp2) |>
+  summarise(across(c(numerator, denominator, epop), sum), .groups = "drop") |> 
+  mutate(sex = "All") |> 
+  create_rates(cats = c("diab_type", "diab_main_flag", "sex", "age_grp2"), epop_total = 200000, sex = T) #Then calculating rates
 
+#Create rates for males and females separately
+admissions_diab_sex <- admissions_diab |> 
+  create_rates(cats = c("diab_type", "diab_main_flag", "sex", "age_grp2"), epop_total = 100000, sex = T) 
 
-saveRDS(admissions_diav, file = paste0(output, "/diabetes_admissions_basefile.rds"))
-admissions_diab <- readRDS(paste0(output, "/diabetes_admissions_basefile.rds")) 
+#Calculate rates for all ages
+all_ages <- admissions_diab |> 
+  group_by(year, fin_year, diab_type, diab_main_flag, sex) |>
+  summarise(across(c(numerator, denominator, epop), sum), .groups = "drop") |>
+  mutate(age_grp2 = "All Ages", age_grp = "All Ages") |> 
+  create_rates(cats = c("diab_type", "diab_main_flag", "sex", "age_grp2"), epop_total = 200000, sex = T) #Then calculating rates
 
+#Calculate rates for all sexes combined and all age groups combined
+all_ages_sexes <- admissions_diab |>
+  group_by(year, fin_year, diab_type, diab_main_flag) |>
+  summarise(across(c(numerator, denominator, epop), sum), .groups = "drop") |>
+  mutate(
+    sex = "All",
+    age_grp = "All Ages",
+    age_grp2 = "All Ages"
+  ) |>
+  create_rates(cats = c("diab_type", "diab_main_flag", "sex", "age_grp2"), epop_total = 200000, sex = TRUE)
 
+admissions_diab <- rbind(all_sexes, admissions_diab_sex, all_ages, all_ages_sexes)
 
-# # # Calculating rates for all and for each sex
-# seccare_c1_total <- seccare_c1_total |>  create_rates(cats = "type", epop_total = 200000, sex = T)
-# seccare_c1_sex <- seccare_c1 |>  create_rates(cats = "type", epop_total = 100000, sex = T)
-# 
-# # # Preparing file for chart
-# seccare_c1 <- rbind(seccare_c1_total, seccare_c1_sex) |>
-#   #Creating labels for chart
-#   mutate(class1 = case_when(type == "e10_main" & sex == "All" ~ "All - main diagnosis",
-#                             type == "e10_any" & sex == "All" ~ "All - any diagnosis",
-#                             type == "e10_main" & sex == "1" ~ "Male - main diagnosis",
-#                             type == "e10_main" & sex == "2" ~ "Female - main diagnosis",
-#                             type == "e10_any" & sex == "1" ~ "Male - any diagnosis",
-#                             type == "e10_any" & sex == "2" ~ "Female - any diagnosis")) |> 
-#   make_year_labels(year_type = "financial") |> #Relabeling years
-#   rename(class2 = year) |>  select(class2, class1, numerator, rate)
-#   
-# write_csv(seccare_c1, paste0(output, "/diabetes_secondarycare_chart1.csv"))
-# 
-# ###############################################.
-# # Creating file for Secondary care section chart 2.
-# #Chart 2 - admissions for type 2 diabetes in main or any position split by sex
-# seccare_c2 <- admissions_diab |> 
-#   filter(type == "e11_main" | type == "e11_any") 
-# 
-# #Create totals for both sexes
-# seccare_c2_total <- seccare_c2 |> 
-#   group_by(year, age_grp, age_grp2, type) |>
-#   summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup() |>
-#   mutate(sex = "All")
-# 
-# # # Calculating rates for all and for each sex
-# seccare_c2_total <- seccare_c2_total |>  create_rates(cats = "type", epop_total = 200000, sex = T)
-# seccare_c2_sex <- seccare_c2 |>  create_rates(cats = "type", epop_total = 100000, sex = T)
-# 
-# # # Preparing file for chart
-# seccare_c2 <- rbind(seccare_c2_total, seccare_c2_sex) |>
-#   #Creating labels for chart
-#   mutate(class1 = case_when(type == "e11_main" & sex == "All" ~ "All - main diagnosis",
-#                             type == "e11_any" & sex == "All" ~ "All - any diagnosis",
-#                             type == "e11_main" & sex == "1" ~ "Male - main diagnosis",
-#                             type == "e11_main" & sex == "2" ~ "Female - main diagnosis",
-#                             type == "e11_any" & sex == "1" ~ "Male - any diagnosis",
-#                             type == "e11_any" & sex == "2" ~ "Female - any diagnosis")) |> 
-#   make_year_labels(year_type = "financial") |> #Relabeling years
-#   rename(class2 = year) |>  select(class2, class1, numerator, rate)
-# 
-# write_csv(seccare_c2, paste0(output, "/diabetes_secondarycare_chart2.csv"))
-# 
-# ###############################################.
-# # Creating file for Secondary care section chart 3.
-# # ketoacidosis - splitting by type 1 and 2
-# seccare_c3_filtered <- admissions_diab |> 
-#   filter(type == "e10_keto") 
-# 
-# seccare_c3_total<- seccare_c3_filtered|> 
-#   group_by(sex, year, age_grp, age_grp2, type) |>
-#   summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup()
-# 
-# 
-# seccare_c3_e10 <- rbind( #calculating rates for each age group
-#   # For under 25 group group
-#   admissions_diab |>  filter(age_grp2 == "<25" & type == "e10_keto") |>  
-#     create_rates(cats = "age_grp2", epop_total = 27500, sex = T),
-#   # For 25 to 44 group
-#   admissions_diab |>  filter(age_grp2 == "25-44" & type == "e10_keto") |>  
-#     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
-#   # For 45 to 64 group
-#   admissions_diab |>  filter(age_grp2 == "45-64" & type == "e10_keto") |> 
-#     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
-#   # For over 65 group
-#   admissions_diab |> filter(age_grp2 == "65+" & type == "e10_keto") |>  
-#     create_rates(cats = "age_grp2", epop_total = 19500, sex = T),
-#   # all ages by sex 
-#   seccare_c3 |>  create_rates(cats = "type", epop_total = 100000, sex = T) |> 
-#     select(-type) |>  
-#     mutate(age_grp2 =  "All")) |> 
-#   mutate(type = "e10_keto")
-# 
-# seccare_c3_filtered <- admissions_diab |> 
-#   filter(type == "e11_keto") 
-# 
-# seccare_c3_total<- seccare_c3_filtered |> 
-#   group_by(sex, year, age_grp, age_grp2, type) |>
-#   summarise_at(c("numerator", "denominator", "epop"), sum, na.rm = T) |>  ungroup()
-# 
-# 
-# seccare_c3_e11 <- rbind( #calculating rates for each age group
-#   # For under 25 group group
-#   admissions_diab |>  filter(age_grp2 == "<25" & type == "e11_keto") |>  
-#     create_rates(cats = "age_grp2", epop_total = 27500, sex = T),
-#   # For 25 to 44 group
-#   admissions_diab |>  filter(age_grp2 == "25-44" & type == "e11_keto") |>  
-#     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
-#   # For 45 to 64 group
-#   admissions_diab |>  filter(age_grp2 == "45-64" & type == "e11_keto") |> 
-#     create_rates(cats = "age_grp2", epop_total = 26500, sex = T),
-#   # For over 65 group
-#   admissions_diab |> filter(age_grp2 == "65+" & type == "e11_keto") |>  
-#     create_rates(cats = "age_grp2", epop_total = 19500, sex = T),
-#   # all ages by sex 
-#   seccare_c3 |>  create_rates(cats = "type", epop_total = 100000, sex = T) |> 
-#     select(-type) |>  
-#     mutate(age_grp2 =  "All")) |> 
-#   mutate(type = "e11_keto")
-# 
-# 
-# seccare_c3_e10_final <- seccare_c3_e10 |> 
-#   #Creating labels for chart
-#   mutate(class1 = case_when(age_grp2 == 'All' & sex == '2' ~ 'Female - all ages',
-#                             age_grp2 == '<25' & sex == '2' ~ 'Female - 0-24',
-#                             age_grp2 == '25-44' & sex == '2' ~ 'Female - 25-44',
-#                             age_grp2 == '45-64' & sex == '2' ~ 'Female - 45-64',
-#                             age_grp2 == '65+' & sex == '2' ~ 'Female - 65+',
-#                             age_grp2 == 'All' & sex == '1' ~ 'Male - all ages',
-#                             age_grp2 == '<25' & sex == '1' ~ 'Male - 0-24',
-#                             age_grp2 == '25-44' & sex == '1' ~ 'Male - 25-44',
-#                             age_grp2 == '45-64' & sex == '1' ~ 'Male - 45-64',
-#                             age_grp2 == '65+' & sex == '1' ~ 'Male - 65+')) |>  
-#   make_year_labels(year_type = "financial") |>   # Relabeling years
-#   rename(class2 = year) |> select(class2, class1, numerator, rate) |> 
-#   mutate(type = "E10")
-# 
-# seccare_c3_e11_final <- seccare_c3_e11 |> 
-#   #Creating labels for chart
-#   mutate(class1 = case_when(age_grp2 == 'All' & sex == '2' ~ 'Female - all ages',
-#                             age_grp2 == '<25' & sex == '2' ~ 'Female - 0-24',
-#                             age_grp2 == '25-44' & sex == '2' ~ 'Female - 25-44',
-#                             age_grp2 == '45-64' & sex == '2' ~ 'Female - 45-64',
-#                             age_grp2 == '65+' & sex == '2' ~ 'Female - 65+',
-#                             age_grp2 == 'All' & sex == '1' ~ 'Male - all ages',
-#                             age_grp2 == '<25' & sex == '1' ~ 'Male - 0-24',
-#                             age_grp2 == '25-44' & sex == '1' ~ 'Male - 25-44',
-#                             age_grp2 == '45-64' & sex == '1' ~ 'Male - 45-64',
-#                             age_grp2 == '65+' & sex == '1' ~ 'Male - 65+')) |>  
-#   make_year_labels(year_type = "financial") |>   # Relabeling years
-#   rename(class2 = year) |> select(class2, class1, numerator, rate) |> 
-#   mutate(type = "E11")
-# 
-# #write_csv(seccare_c3, paste0(output, "/diabetes_secondarycare_chart3.csv))
-# #Preserving chart 3 above which is ketoacidosis not split by type
-# write_csv(seccare_c3_e10_final, paste0(output, "/diabetes_secondarycare_chart4.csv"))
-# write_csv(seccare_c3_e11_final, paste0(output, "/diabetes_secondarycare_chart5.csv"))
+#Convert numeric sex to character
+admissions_diab <- admissions_diab |> 
+  mutate(sex = case_when(sex == 1 ~ "Male",
+                         sex == 2 ~ "Female",
+                         TRUE ~ "All"))
+
+#Pivot longer to have a "measure" col
+admissions_diab_final <- admissions_diab |> 
+  tidyr::pivot_longer(cols = c(numerator, rate), names_to = "measure", values_to = "value") |> 
+  mutate(measure = str_to_title(measure)) 
+
+saveRDS(admissions_diab_final, file.path(output, "/diabetes_admissions_basefile.rds"))
+write.csv(admissions_diab_final, file.path(output, "/diabetes_admissions.csv"))
 
 ###############################################.
 ## Part 3 - Deaths data ----
 ###############################################.
-
-# deaths_diab <- tibble::as_tibble(
-#   dbGetQuery(channel, statement=
-#                "SELECT year_of_registration year, sex, age,  
-#     sum(case when regexp_like(UNDERLYING_CAUSE_OF_DEATH, 'E10') then 1 else 0 end) main_diag_e10,
-#     sum(case when regexp_like(UNDERLYING_CAUSE_OF_DEATH, 'E11') then 1 else 0 end) main_diag_e11,
-#     sum(case when regexp_like(UNDERLYING_CAUSE_OF_DEATH || cause_of_death_code_0 ||
-#       cause_of_death_code_1 ||  cause_of_death_code_2 ||  cause_of_death_code_3 || 
-#       cause_of_death_code_4 ||  cause_of_death_code_5 ||  cause_of_death_code_6 || 
-#       cause_of_death_code_7 ||  cause_of_death_code_8 ||  cause_of_death_code_9,
-#       'E10') then 1 else 0 end) any_diag_e10,
-#     sum(case when regexp_like(UNDERLYING_CAUSE_OF_DEATH || cause_of_death_code_0 ||
-#       cause_of_death_code_1 ||  cause_of_death_code_2 ||  cause_of_death_code_3 || 
-#       cause_of_death_code_4 ||  cause_of_death_code_5 ||  cause_of_death_code_6 || 
-#       cause_of_death_code_7 ||  cause_of_death_code_8 ||  cause_of_death_code_9,
-#       'E11') then 1 else 0 end) any_diag_e11  
-#   FROM ANALYSIS.GRO_DEATHS_C 
-#   WHERE year_of_registration between 2011 and 2023
-#     and country_of_residence= 'XS' 
-#     and sex <> 9 
-#     and regexp_like(UNDERLYING_CAUSE_OF_DEATH || cause_of_death_code_0 ||
-#       cause_of_death_code_1 ||  cause_of_death_code_2 ||  cause_of_death_code_3 || 
-#       cause_of_death_code_4 ||  cause_of_death_code_5 ||  cause_of_death_code_6 || 
-#       cause_of_death_code_7 ||  cause_of_death_code_8 ||  cause_of_death_code_9,
-#       'E1[01234]') 
-#   GROUP BY year_of_registration, sex, age ")) |> 
-#   janitor::clean_names()  #variables to lower case
-
-
 deaths_diab <- tibble::as_tibble(
   dbGetQuery(channel, statement = 
             "SELECT year_of_registration, sex, age, underlying_cause_of_death,

--- a/Diabetes update.R
+++ b/Diabetes update.R
@@ -10,9 +10,9 @@
 ###############################################.
 # load packages and functions required to run all commands
 source("1.analysis_functions.R")
-library(stringr)
-library(purrr)
-library(janitor)
+library(stringr) #for manipulating strings
+library(purrr) #for handling lists
+library(janitor) #for tidying up data
 
 # set files paths. folder will have to be created for newest year's data
 
@@ -30,8 +30,8 @@ population <- readRDS(file.path(lookups, "CA_pop_allages_SR.rds")) |>
                           between(age_grp, 6, 9) ~ "25-44",
                           between(age_grp, 10, 13) ~ "45-64",
                           between(age_grp, 14, 19) ~ "65+"),
-  sex = as.character(sex_grp)) |> 
-  group_by(year, sex, age_grp, age_grp2) |> #aggregating
+  sex = as.character(sex_grp)) |> #convert sex to character from numeric
+  group_by(year, sex, age_grp, age_grp2) |> #aggregating on age groups
   summarise_at(c("denominator", "epop"), sum, na.rm = TRUE) |>  ungroup()
 
 ###############################################.
@@ -45,101 +45,104 @@ channel <- suppressWarnings(dbConnect(odbc(),  dsn="SMRA",
 # This query extracts data for all episodes of patients for which in any occasion there was a diagnosis of diabetes.
 # It excludes patients with no sex recorded and patients who were not Scottish residents
 
-admissions_diab_test <- tibble::as_tibble(dbGetQuery(channel, statement = 
-"Select age_in_years, sex, main_condition, other_condition_1, other_condition_2, 
-other_condition_3, other_condition_4, other_condition_5, discharge_date, uri, cis_marker, link_no
-FROM ANALYSIS.SMR01_PI
-WHERE(
-discharge_date between '1 April 2011' and '31 March 2024'
-and hbtreat_currentdate is not null
-and sex in ('1', '2')
-and regexp_like(main_condition || other_condition_1 || other_condition_2
-            || other_condition_3 || other_condition_4 || other_condition_5, 'E1[01234]'))
-ORDER BY link_no, cis_marker, discharge_date, uri")) |> 
-  janitor::clean_names() #names to lower case
+admissions_diab <- tibble::as_tibble(dbGetQuery(channel, statement = 
+"SELECT z.year, z.age, z.sex, 
+SUM(z.t1dm_main) AS t1dm_main, SUM(z.t2dm_main) AS t2dm_main, SUM(z.othdm_main) AS othdm_main,
+SUM(z.t1dm_any) AS t1dm_any, SUM(z.t2dm_any) AS t2dm_any, SUM(z.othdm_any) AS othdm_any,
+SUM(z.t1dm_keto_main) AS t1dm_keto_main, SUM(z.t2dm_keto_main) AS t2dm_keto_main, SUM(z.othdm_keto_main) AS othdm_keto_main,
+SUM(z.t1dm_keto_any) AS t1dm_keto_any, SUM(z.t2dm_keto_any) AS t2dm_keto_any, SUM(z.othdm_keto_any) AS othdm_keto_any
+FROM (SELECT link_no, cis_marker, MAX(age_in_years) AS age, MAX(sex) AS sex, 
+    MAX(CASE WHEN EXTRACT(MONTH FROM discharge_date) > 3 
+      THEN EXTRACT(YEAR FROM discharge_date)
+      ELSE EXTRACT(YEAR FROM discharge_date) - 1 
+      END
+    ) AS year,
+    MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E10') THEN 1 ELSE 0 END) AS t1dm_main,
+    MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E11') THEN 1 ELSE 0 END) AS t2dm_main,
+    MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E1[234]') THEN 1 ELSE 0 END) AS othdm_main,
+    MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
+        other_condition_3 || other_condition_4 || other_condition_5, '^E10'
+    ) THEN 1 ELSE 0 END) AS t1dm_any,
+  MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
+      other_condition_3 || other_condition_4 || other_condition_5, '^E11'
+  ) THEN 1 ELSE 0 END) AS t2dm_any,
+  MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
+      other_condition_3 || other_condition_4 || other_condition_5, '^E1[234]'
+  ) THEN 1 ELSE 0 END) AS othdm_any,
+   MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E101') THEN 1 ELSE 0 END) AS t1dm_keto_main,
+   MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E111') THEN 1 ELSE 0 END) AS t2dm_keto_main,
+   MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E1[234]1') THEN 1 ELSE 0 END) AS othdm_keto_main,
+       MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
+        other_condition_3 || other_condition_4 || other_condition_5, 'E101'
+    ) THEN 1 ELSE 0 END) AS t1dm_keto_any,
+  MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
+      other_condition_3 || other_condition_4 || other_condition_5,'E111'
+  ) THEN 1 ELSE 0 END) AS t2dm_keto_any,
+  MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
+      other_condition_3 || other_condition_4 || other_condition_5,'E1[234]1'
+  ) THEN 1 ELSE 0 END) AS othdm_keto_any
+  FROM ANALYSIS.SMR01_PI
+  WHERE
+  discharge_date BETWEEN '1 April 2011' AND '31 March 2025'
+  AND hbtreat_currentdate IS NOT NULL
+  AND sex IN ('1','2')
+  AND REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
+        other_condition_3 || other_condition_4 || other_condition_5,'^E1[01234]')
+    GROUP BY 
+  link_no, cis_marker
+) z
+  GROUP BY 
+z.year, z.age, z.sex
+ORDER BY 
+z.year, z.age, z.sex;")) |> 
+  clean_names() #names to lower case
 
-# Identify diagnosis columns by name
-diag_cols <- names(admissions_diab_test)[3:8] 
+#Create columns needed for dropdowns in app
+admissions_diab2 <- admissions_diab |> 
+  tidyr::pivot_longer(cols = c(4:15), names_to = "variable", values_to = "count") |> #pivot all the categories into 1 col
+  mutate(diab_type = case_when(variable = str_detect(variable, "1") ~ "Type 1", #assign diabetes types to each category
+                               variable = str_detect(variable, "2") ~ "Type 2",
+                               variable = str_detect(variable, "oth") ~ "Other Diabetes",
+                               TRUE ~ NA_character_),
+         diab_main = case_when(variable = str_detect(variable, "m_main") ~ "Main Position", #assign diabetes positions / keto diagnosis
+                               variable = str_detect(variable, "m_any") ~ "Any Position",
+                               variable = str_detect(variable, "keto") ~ "Diabetic Ketoacidosis",
+                               TRUE ~ NA_character_)) 
 
-#Tidying up the data and creating some variables based on conditions present in admission and their position
-admissions_diab <- admissions_diab_test |> 
-  distinct(link_no, cis_marker, .keep_all = TRUE) |> #Aggregating by link_no and cis to prevent duplication of stays
-  mutate(
-    fin_year = phsmethods::extract_fin_year(discharge_date),  #convert the date of discharge into a financial year
-    year = as.numeric(substr(fin_year, 1, 4))) |>  #keep first year of fy
-  mutate(diab_keto = pmap_int(select(cur_data(), all_of(diag_cols)), function(...) { #using purrr for rowwise operations as it's more efficient
-      codes <- c(...)
-      if (any(str_detect(codes, 'E101|E111|E121|E131|E141'), na.rm = TRUE)) 1 else 0}), #searches all condition spaces for diabetic ketoacidosis and flags if found
-      diab_type = pmap_chr(select(cur_data(), all_of(diag_cols)), function(...) {
-      codes <- c(...)
-      case_when(
-        any(str_detect(codes, '^E10'), na.rm = TRUE) ~ "Type 1",
-        any(str_detect(codes, '^E11'), na.rm = TRUE) ~ "Type 2",
-        TRUE ~ "Other Diabetes")}), #Creating a diab_type column with the diabetes type based on all diagnosis columns
-    diab_main_flag = case_when(
-      str_detect(main_condition, "E1[01234]") ~ "Main Position",
-      TRUE ~ "Any Position")) |>  #Creating a flag to distinguish between admissions primarily due to diabetes and all admissions in diabetes sufferers
-  rename(age = age_in_years)
-
-#Aggregating data by age group and other categories created
-admissions_diab<- admissions_diab |> 
-  create_agegroups() |>  
-  group_by(sex, year, diab_keto, diab_type, diab_main_flag, age_grp, fin_year) |> #counting number of admissions for each category.
+#Aggregate age groups
+admissions_diab3 <- admissions_diab2 |> 
+  create_agegroups() |>  #create age groups
+  group_by(sex, year, diab_type, diab_main, age_grp) |> 
   summarise(numerator = n(), .groups = "drop") |> 
-  complete(sex, year, fin_year, diab_keto, diab_type, diab_main_flag, age_grp, fill = list(numerator = 0)) |>  #filling in blank categories with 0 admissions
   mutate(age_grp2 = case_when(between(age_grp, 1, 5) ~ "<25",
                                 between(age_grp, 6, 9) ~ "25-44",
                                 between(age_grp, 10, 13) ~ "45-64",
                                 between(age_grp, 14, 19) ~ "65+")) 
 
-#Adding keto acidosis as a type of admission alongside main/any
-admissions_diab_keto <- admissions_diab |> 
-  filter(diab_keto == 1) |> 
-  select(-diab_keto) |> 
-  mutate(diab_main_flag = "Diabetic Ketoacidosis") |> 
-  group_by(sex, year, fin_year, diab_type, diab_main_flag, age_grp, age_grp2) |> 
-  summarise(numerator = sum(numerator), .groups = "drop")
-
-#Appending back on to data - so some redundancy if the patient was a type 1 diabetes admission for ketoacidosis. 
-admissions_diab <- admissions_diab |> 
-  filter(diab_keto == 0) |> 
-  select(-diab_keto)
-
-admissions_diab <- rbind(admissions_diab, admissions_diab_keto)
-
 #Bringing population information to calculate rates.
-admissions_diab <- left_join(admissions_diab, population, 
+admissions_diab4 <- left_join(admissions_diab3, population, 
                              by = c("year", "sex", "age_grp", "age_grp2")) |>  
   add_epop() #adding European population for rate calculation 
 
 #Aggregate figures for males and females to get all sexes
-all_sexes <- admissions_diab |> #combining the data for males and females to get a count for both sexes combined
-  group_by(year, fin_year, diab_type, diab_main_flag, age_grp, age_grp2) |>
-  summarise(across(c(numerator, denominator, epop), sum), .groups = "drop") |> 
+all_sexes <- admissions_diab4 |> #combining the data for males and females to get a count for both sexes combined
   mutate(sex = "All") |> 
-  create_rates(cats = c("diab_type", "diab_main_flag", "sex", "age_grp2"), epop_total = 200000, sex = T) #Then calculating rates
+  create_rates(cats = c("diab_type", "diab_main", "age_grp2"), epop_total = 200000, sex = F) |> #Then calculating rates
+  mutate(sex = "All")
 
 #Create rates for males and females separately
-admissions_diab_sex <- admissions_diab |> 
-  create_rates(cats = c("diab_type", "diab_main_flag", "sex", "age_grp2"), epop_total = 100000, sex = T) 
+admissions_diab_sex <- admissions_diab4 |> 
+  create_rates(cats = c("diab_type", "diab_main", "sex", "age_grp2"), epop_total = 100000, sex = T) 
 
 #Calculate rates for all ages
-all_ages <- admissions_diab |> 
-  group_by(year, fin_year, diab_type, diab_main_flag, sex) |>
-  summarise(across(c(numerator, denominator, epop), sum), .groups = "drop") |>
-  mutate(age_grp2 = "All Ages", age_grp = "All Ages") |> 
-  create_rates(cats = c("diab_type", "diab_main_flag", "sex", "age_grp2"), epop_total = 200000, sex = T) #Then calculating rates
+all_ages <- admissions_diab4 |> 
+  create_rates(cats = c("diab_type", "diab_main", "sex"), epop_total = 100000, sex = T) |>  #Then calculating rates
+  mutate(age_grp2 = "All ages")
 
 #Calculate rates for all sexes combined and all age groups combined
-all_ages_sexes <- admissions_diab |>
-  group_by(year, fin_year, diab_type, diab_main_flag) |>
-  summarise(across(c(numerator, denominator, epop), sum), .groups = "drop") |>
-  mutate(
-    sex = "All",
-    age_grp = "All Ages",
-    age_grp2 = "All Ages"
-  ) |>
-  create_rates(cats = c("diab_type", "diab_main_flag", "sex", "age_grp2"), epop_total = 200000, sex = TRUE)
+all_ages_sexes <- admissions_diab4 |>
+  create_rates(cats = c("diab_type", "diab_main"), epop_total = 200000, sex = F) |> 
+  mutate(sex = "All", age_grp2 = "All ages")
 
 admissions_diab <- rbind(all_sexes, admissions_diab_sex, all_ages, all_ages_sexes)
 
@@ -152,10 +155,11 @@ admissions_diab <- admissions_diab |>
 #Pivot longer to have a "measure" col
 admissions_diab_final <- admissions_diab |> 
   tidyr::pivot_longer(cols = c(numerator, rate), names_to = "measure", values_to = "value") |> 
-  mutate(measure = str_to_title(measure)) 
+  mutate(measure = str_to_title(measure),
+         value = round(value, digits = 1))
 
 saveRDS(admissions_diab_final, file.path(output, "/diabetes_admissions_basefile.rds"))
-write.csv(admissions_diab_final, file.path(output, "/diabetes_admissions.csv"))
+write.csv(admissions_diab_final, file.path(output, "/diabetes_admissions.csv"), row.names = F)
 
 ###############################################.
 ## Part 3 - Deaths data ----
@@ -169,7 +173,7 @@ deaths_diab <- tibble::as_tibble(
             cause_of_death_code_9
             FROM ANALYSIS.GRO_Deaths_C
             WHERE(
-            year_of_registration between 2011 and 2023
+            year_of_registration between 2011 and 2024
             and country_of_residence = 'XS'
             and sex in ('1', '2')
             and regexp_like(underlying_cause_of_death || 
@@ -227,5 +231,6 @@ deaths_diab <- tibble::as_tibble(
     
   
   saveRDS(deaths_diab_cleaned, paste0(output, "/deaths_data_shiny_test.rds"))
+  write.csv(deaths_diab_cleaned, paste0(output, "/deaths_data_shiny_test.csv"), row.names = F)
 
 ##END

--- a/Diabetes update.R
+++ b/Diabetes update.R
@@ -16,7 +16,7 @@ library(janitor) #for tidying up data
 
 # set files paths. folder will have to be created for newest year's data
 
-  output <- "/PHI_conf/ScotPHO/Website/Topics/Diabetes/Data/Jun25"
+  output <- "/PHI_conf/ScotPHO/Website/Topics/Diabetes/Data/Jun26"
   lookups <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Population/"
 
 ###############################################.
@@ -60,34 +60,44 @@ FROM (SELECT link_no, cis_marker, MAX(age_in_years) AS age, MAX(sex) AS sex,
     MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E10') THEN 1 ELSE 0 END) AS t1dm_main,
     MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E11') THEN 1 ELSE 0 END) AS t2dm_main,
     MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E1[234]') THEN 1 ELSE 0 END) AS othdm_main,
-    MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
-        other_condition_3 || other_condition_4 || other_condition_5, '^E10'
+    MAX(CASE WHEN (REGEXP_LIKE(main_condition, '^E10') OR REGEXP_LIKE(other_condition_1, '^E10') OR
+    REGEXP_LIKE(other_condition_2, '^E10') OR REGEXP_LIKE(other_condition_3, '^E10') OR
+    REGEXP_LIKE(other_condition_4, '^E10') OR REGEXP_LIKE(other_condition_5, '^E10')
     ) THEN 1 ELSE 0 END) AS t1dm_any,
-  MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
-      other_condition_3 || other_condition_4 || other_condition_5, '^E11'
-  ) THEN 1 ELSE 0 END) AS t2dm_any,
-  MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
-      other_condition_3 || other_condition_4 || other_condition_5, '^E1[234]'
-  ) THEN 1 ELSE 0 END) AS othdm_any,
+    MAX(CASE WHEN (REGEXP_LIKE(main_condition, '^E11') OR REGEXP_LIKE(other_condition_1, '^E11') OR
+    REGEXP_LIKE(other_condition_2, '^E11') OR REGEXP_LIKE(other_condition_3, '^E11') OR
+    REGEXP_LIKE(other_condition_4, '^E11') OR REGEXP_LIKE(other_condition_5, '^E11')
+    ) THEN 1 ELSE 0 END) AS t2dm_any,
+    MAX(CASE WHEN (REGEXP_LIKE(main_condition, '^E1[234]') OR REGEXP_LIKE(other_condition_1, '^E1[234]') OR
+    REGEXP_LIKE(other_condition_2, '^E1[234]') OR REGEXP_LIKE(other_condition_3, '^E1[234]') OR
+    REGEXP_LIKE(other_condition_4, '^E1[234]') OR REGEXP_LIKE(other_condition_5, '^E1[234]')
+    ) THEN 1 ELSE 0 END) AS othdm_any,
    MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E101') THEN 1 ELSE 0 END) AS t1dm_keto_main,
    MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E111') THEN 1 ELSE 0 END) AS t2dm_keto_main,
    MAX(CASE WHEN REGEXP_LIKE(main_condition, '^E1[234]1') THEN 1 ELSE 0 END) AS othdm_keto_main,
-       MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
-        other_condition_3 || other_condition_4 || other_condition_5, 'E101'
-    ) THEN 1 ELSE 0 END) AS t1dm_keto_any,
-  MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
-      other_condition_3 || other_condition_4 || other_condition_5,'E111'
-  ) THEN 1 ELSE 0 END) AS t2dm_keto_any,
-  MAX(CASE WHEN REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
-      other_condition_3 || other_condition_4 || other_condition_5,'E1[234]1'
-  ) THEN 1 ELSE 0 END) AS othdm_keto_any
+   MAX(CASE WHEN (REGEXP_LIKE(main_condition, 'E101') OR REGEXP_LIKE(other_condition_1, 'E101') OR
+   REGEXP_LIKE(other_condition_2, 'E101') OR REGEXP_LIKE(other_condition_3, 'E101') OR 
+   REGEXP_LIKE(other_condition_4, 'E101') OR REGEXP_LIKE(other_condition_5, 'E101')
+   ) THEN 1 ELSE 0 END) AS t1dm_keto_any,
+   MAX(CASE WHEN (REGEXP_LIKE(main_condition, 'E111') OR REGEXP_LIKE(other_condition_1, 'E111') OR
+   REGEXP_LIKE(other_condition_2, 'E111') OR REGEXP_LIKE(other_condition_3, 'E111') OR 
+   REGEXP_LIKE(other_condition_4, 'E111') OR REGEXP_LIKE(other_condition_5, 'E111')
+   ) THEN 1 ELSE 0 END) AS t2dm_keto_any,
+   MAX(CASE WHEN (REGEXP_LIKE(main_condition, 'E1[234]1') OR REGEXP_LIKE(other_condition_1, 'E1[234]1') OR
+   REGEXP_LIKE(other_condition_2, 'E1[234]1') OR REGEXP_LIKE(other_condition_3, 'E1[234]1') OR 
+   REGEXP_LIKE(other_condition_4, 'E1[234]1') OR REGEXP_LIKE(other_condition_5, 'E1[234]1')
+   ) THEN 1 ELSE 0 END) AS othdm_keto_any
   FROM ANALYSIS.SMR01_PI
   WHERE
   discharge_date BETWEEN '1 April 2011' AND '31 March 2025'
   AND hbtreat_currentdate IS NOT NULL
   AND sex IN ('1','2')
-  AND REGEXP_LIKE(main_condition || other_condition_1 || other_condition_2 ||
-        other_condition_3 || other_condition_4 || other_condition_5,'^E1[01234]')
+    AND (REGEXP_LIKE(main_condition, '^E1[01234]') OR
+    REGEXP_LIKE(other_condition_1, '^E1[01234]') OR
+    REGEXP_LIKE(other_condition_2, '^E1[01234]') OR
+    REGEXP_LIKE(other_condition_3, '^E1[01234]') OR
+    REGEXP_LIKE(other_condition_4, '^E1[01234]') OR
+    REGEXP_LIKE(other_condition_5, '^E1[01234]'))
     GROUP BY 
   link_no, cis_marker
 ) z
@@ -96,24 +106,24 @@ z.year, z.age, z.sex
 ORDER BY 
 z.year, z.age, z.sex;")) |> 
   clean_names() #names to lower case
-
+    
 #Create columns needed for dropdowns in app
 admissions_diab2 <- admissions_diab |> 
   tidyr::pivot_longer(cols = c(4:15), names_to = "variable", values_to = "count") |> #pivot all the categories into 1 col
-  mutate(diab_type = case_when(variable = str_detect(variable, "1") ~ "Type 1", #assign diabetes types to each category
-                               variable = str_detect(variable, "2") ~ "Type 2",
-                               variable = str_detect(variable, "oth") ~ "Other Diabetes",
+  mutate(diab_type = case_when(str_detect(variable, "1") ~ "Type 1", #assign diabetes types to each category
+                               str_detect(variable, "2") ~ "Type 2",
+                               str_detect(variable, "oth") ~ "Other Diabetes",
                                TRUE ~ NA_character_),
-         diab_main = case_when(variable = str_detect(variable, "m_main") ~ "Main Position", #assign diabetes positions / keto diagnosis
-                               variable = str_detect(variable, "m_any") ~ "Any Position",
-                               variable = str_detect(variable, "keto") ~ "Diabetic Ketoacidosis",
-                               TRUE ~ NA_character_)) 
+         diab_main = case_when(str_detect(variable, "keto") ~ "Diabetic Ketoacidosis", #assign diagnosis position. Treating ketoacidosis like a position as it can also occur in t1 or t2
+                               str_detect(variable, "m_main") ~ "Main Position",
+                               str_detect(variable, "m_any") ~ "Any Position",
+                               TRUE ~ NA_character_))
 
 #Aggregate age groups
 admissions_diab3 <- admissions_diab2 |> 
   create_agegroups() |>  #create age groups
   group_by(sex, year, diab_type, diab_main, age_grp) |> 
-  summarise(numerator = n(), .groups = "drop") |> 
+  summarise(numerator = sum(count), .groups = "drop") |> 
   mutate(age_grp2 = case_when(between(age_grp, 1, 5) ~ "<25",
                                 between(age_grp, 6, 9) ~ "25-44",
                                 between(age_grp, 10, 13) ~ "45-64",

--- a/Diabetes update.R
+++ b/Diabetes update.R
@@ -10,7 +10,6 @@
 ###############################################.
 # load packages and functions required to run all commands
 source("1.analysis_functions.R")
-
 library(stringr)
 
 # set files paths. folder will have to be created for newest year's data
@@ -21,7 +20,7 @@ library(stringr)
 ###############################################.
 ## Part 1 - Population files ----
 ###############################################.
-population <- readRDS(paste0(lookups, "CA_pop_allages_SR.rds")) |> 
+population <- readRDS(file.path(lookups, "CA_pop_allages_SR.rds")) |> 
   filter(code == 'S00000001') |>   # Selecting only Scotland level
   add_epop() |>  # Add European Standard Populations for each age group
   # Create required age groups  (<25, 25-44, 45-64, 65+)
@@ -76,8 +75,12 @@ admissions_diab <- admissions_diab_test |>
          diab_main_flag = case_when(str_detect(main_condition, "E1[01234]") ~ "Main Position", TRUE ~ "Any Position")) |>  #identifies whether diabetes was the primary cause of admission
   ungroup() 
 
+#Aggregating by link_no and cis to prevent duplication of stays
+admissions_diab_1.5 <- admissions_diab |> 
+  distinct(link_no, cis_marker, .keep_all = TRUE)
+
 #Aggregating data by age group and other categories created
-admissions_diab_2 <- admissions_diab |> create_agegroups() |>  
+admissions_diab_2 <- admissions_diab_1.5 |> create_agegroups() |>  
   group_by(sex, year, diab_keto, diab_type, diab_main_flag, age_grp) |> #counting number of admissions for each category.
   summarise(numerator = n(), .groups = "drop") |> 
   complete(sex, year, diab_keto, diab_type, diab_main_flag, age_grp, fill = list(numerator = 0)) |>  #filling in blank categories with 0 admissions


### PR DESCRIPTION
Hi Monica,

Here are the changes I've made to the diabetes script to update to 23/24 and split all charts on the secondary care and mortality pages by type 1 and type 2. It's been a bit of a challenge to balance the number of charts and the axis scales, so I have split the charts by type rather than e.g. by diagnosis position or sex. This means that we are now presenting type 1 and 2 and the "other" types (e.g. nutritional diabetes) have been excluded. Please let me know if you notice any issues.

For secondary care charts 3, 4 and 5, I have kept 3 as the ketoacidosis rates not split by type, then charts 4 and 5 are split by type 1 and type 2. On the website it should end up being one or the other published.

Thanks,
Abbie